### PR TITLE
Add init for IdentityRequest and allow custom urlscheme

### DIFF
--- a/app/src/main/java/com/cotter/app/Cotter.java
+++ b/app/src/main/java/com/cotter/app/Cotter.java
@@ -47,6 +47,16 @@ public class Cotter {
         methods = new CotterMethodHelper(context);
     }
 
+    // Init function for Identity Request (No user yet + using PKCE)
+    public static void init(Context context, String mainServerURL, String apiKeyID) {
+        ApiKeyID = apiKeyID;
+        ctx = context;
+        authRequest = new AuthRequest(mainServerURL);
+        strings = new Strings();
+        colors = new Colors();
+        methods = new CotterMethodHelper(context);
+    }
+
     public static User getUser(AuthRequest authRequest) {
         return User.getInstance(ctx, authRequest);
     }
@@ -68,15 +78,8 @@ public class Cotter {
 
 
     // Identity Request
-    public static IdentityRequest getIdentity() {
-        if (identity == null) {
-            Log.e("COTTER IDENTITY", "You need to call newIdentity when calling .login");
-            identity = new IdentityRequest(ctx);
-        }
-        return identity;
-    }
-    public static IdentityRequest newIdentity(Context ctx) {
-        identity = new IdentityRequest(ctx);
+    public static IdentityRequest newIdentity(Context ctx, String urlScheme) {
+        identity = new IdentityRequest(ctx, urlScheme);
         return identity;
     }
 }

--- a/app/src/main/java/com/cotter/app/IdentityRequest.java
+++ b/app/src/main/java/com/cotter/app/IdentityRequest.java
@@ -21,10 +21,11 @@ public class IdentityRequest {
     String state;
     Context ctx;
 
-    public IdentityRequest(Context ctx) {
+    public IdentityRequest(Context ctx, String urlScheme) {
         this.ctx = ctx;
         codeVerifier = generateCodeVerifier();
         codeChallenge = generateCodeChallenge(codeVerifier);
+        this.URL_SCHEME = urlScheme;
 
         Log.i("CODE VERIFIER", codeVerifier);
         Log.i("CODE CHALLENGE", codeChallenge);


### PR DESCRIPTION
Fix URL Scheme. Client need to specify their own URL scheme to ensure the URL scheme is different for each app.